### PR TITLE
Support for CTSM variable names

### DIFF
--- a/src/ILAMB/ConfAlbedo.py
+++ b/src/ILAMB/ConfAlbedo.py
@@ -54,11 +54,13 @@ class ConfAlbedo(Confrontation):
 
         # Handle model data
         dn_mod = m.extractTimeSeries("rsds",
+                                     alternate_vars = ["FSDS"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,
                                      lons         = None if obs.spatial else obs.lon)
         up_mod = m.extractTimeSeries("rsus",
+                                     alternate_vars = ["FSR"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,

--- a/src/ILAMB/ConfAlbedo.py
+++ b/src/ILAMB/ConfAlbedo.py
@@ -54,13 +54,13 @@ class ConfAlbedo(Confrontation):
 
         # Handle model data
         dn_mod = m.extractTimeSeries("rsds",
-                                     alternate_vars = ["FSDS"],
+                                     alt_vars = ["FSDS"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,
                                      lons         = None if obs.spatial else obs.lon)
         up_mod = m.extractTimeSeries("rsus",
-                                     alternate_vars = ["FSR"],
+                                     alt_vars = ["FSR"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,

--- a/src/ILAMB/ConfBurntArea.py
+++ b/src/ILAMB/ConfBurntArea.py
@@ -24,7 +24,9 @@ class ConfBurntArea(Confrontation):
             mod.convert(obs.unit)
         except:
             mod.convert("d-1")
-            mod.data *= np.diff(mod.time_bnds,axis=1)
+            dt = mod.time_bnds[:,1]-mod.time_bnds[:,0]
+            for i in range(mod.data.ndim-1): dt = np.expand_dims(dt,axis=-1)
+            mod.data *= dt
             mod.unit  = "1"
         obs,mod = il.MakeComparable(obs,mod,
                                     mask_ref  = True,

--- a/src/ILAMB/ConfBurntArea.py
+++ b/src/ILAMB/ConfBurntArea.py
@@ -1,0 +1,34 @@
+from .Confrontation import Confrontation
+from .Variable import Variable
+from . import ilamblib as il
+import numpy as np
+
+class ConfBurntArea(Confrontation):
+    """
+    Burnt area is sometimes expressed as a total per month, and
+    sometimes as the mean rate in the month. This specialized code
+    detects the difference and converts.
+    """
+    def stageData(self,m):
+        obs = Variable(filename       = self.source,
+                       variable_name  = self.variable,
+                       alternate_vars = self.alternate_vars,
+                       t0 = None if len(self.study_limits) != 2 else self.study_limits[0],
+                       tf = None if len(self.study_limits) != 2 else self.study_limits[1])
+        mod = m.extractTimeSeries(self.variable,
+                                  alt_vars     = self.alternate_vars,
+                                  expression   = self.derived,
+                                  initial_time = obs.time_bnds[ 0,0],
+                                  final_time   = obs.time_bnds[-1,1])
+        try:
+            mod.convert(obs.unit)
+        except:
+            mod.convert("d-1")
+            mod.data *= np.diff(mod.time_bnds,axis=1)
+            mod.unit  = "1"
+        obs,mod = il.MakeComparable(obs,mod,
+                                    mask_ref  = True,
+                                    clip_ref  = True,
+                                    extents   = self.extents,
+                                    logstring = "[%s][%s]" % (self.longname,m.name))
+        return obs,mod

--- a/src/ILAMB/ConfEvapFraction.py
+++ b/src/ILAMB/ConfEvapFraction.py
@@ -56,13 +56,13 @@ class ConfEvapFraction(Confrontation):
 
         # Handle model data
         sh_mod = m.extractTimeSeries("hfss",
-                                     alternate_vars = ["FSH"],
+                                     alt_vars = ["FSH"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,
                                      lons         = None if obs.spatial else obs.lon)
         le_mod = m.extractTimeSeries("hfls",
-                                     alternate_vars = ["EFLX_LH_TOT"],
+                                     alt_vars = ["EFLX_LH_TOT"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,

--- a/src/ILAMB/ConfEvapFraction.py
+++ b/src/ILAMB/ConfEvapFraction.py
@@ -56,11 +56,13 @@ class ConfEvapFraction(Confrontation):
 
         # Handle model data
         sh_mod = m.extractTimeSeries("hfss",
+                                     alternate_vars = ["FSH"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,
                                      lons         = None if obs.spatial else obs.lon)
         le_mod = m.extractTimeSeries("hfls",
+                                     alternate_vars = ["EFLX_LH_TOT"],
                                      initial_time = obs.time_bnds[ 0,0],
                                      final_time   = obs.time_bnds[-1,1],
                                      lats         = None if obs.spatial else obs.lat,

--- a/src/ILAMB/ModelResult.py
+++ b/src/ILAMB/ModelResult.py
@@ -168,9 +168,12 @@ class ModelResult():
             return (lon<=180)*lon + (lon>180)*(lon-360) + (lon<-180)*360
         
         # Are there cell areas associated with this model?
-        if "areacella" in self.variables.keys():
-            with Dataset(self.variables["areacella"][0]) as f:
-                self.cell_areas = f.variables["areacella"][...]
+        area_name = None
+        area_name = "area"      if "area"      in self.variables.keys() else area_name
+        area_name = "areacella" if "areacella" in self.variables.keys() else area_name
+        if area_name is not None:
+            with Dataset(self.variables[area_name][0]) as f:
+                self.cell_areas = f.variables[area_name][...]
         else:
             if not ("lat_bnds" in self.variables.keys() and
                     "lon_bnds" in self.variables.keys()): return
@@ -185,11 +188,14 @@ class ModelResult():
             self.cell_areas = il.CellAreas(None,None,lat_bnds=x,lon_bnds=y)
             
         # Now we do the same for land fractions
-        if "sftlf" not in self.variables.keys():
+        frac_name = None
+        frac_name = "landfrac" if "landfrac" in self.variables.keys() else frac_name
+        frac_name = "sftlf"    if "sftlf"    in self.variables.keys() else frac_name
+        if frac_name is None:
             self.land_areas = self.cell_areas
         else:
-            with Dataset(self.variables["sftlf"][0]) as f:
-                self.land_fraction = f.variables["sftlf"][...]                
+            with Dataset(self.variables[frac_name][0]) as f:
+                self.land_fraction = f.variables[frac_name][...]                
             # some models represent the fraction as a percent
             if np.ma.max(self.land_fraction) > 10: self.land_fraction *= 0.01
             with np.errstate(over='ignore',under='ignore'):

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -11,6 +11,7 @@ from .ConfSWE import ConfSWE
 from .ConfCO2 import ConfCO2
 from .ConfSoilCarbon import ConfSoilCarbon
 from .ConfUncertainty import ConfUncertainty
+from .ConfBurntArea import ConfBurntArea
 from .Regions import Regions
 import os,re
 from netCDF4 import Dataset
@@ -296,7 +297,8 @@ ConfrontationTypes = { None              : Confrontation,
                        "ConfSWE"         : ConfSWE,
                        "ConfCO2"         : ConfCO2,
                        "ConfSoilCarbon"  : ConfSoilCarbon,
-                       "ConfUncertainty" : ConfUncertainty}
+                       "ConfUncertainty" : ConfUncertainty,
+                       "ConfBurntArea"   : ConfBurntArea}
 
 class Scoreboard():
     """


### PR DESCRIPTION
The aim of this PR is to support NCAR to allow ILAMB to run on h0 files directly. For the most part, this is handled without changes to the repository by adding `alt_vars` to a local configure file. However, the Albedo and EvapFrac confrontations hard code the reading of the component variables which we expanded to allow CTSM names.

We also allow for `landfrac` as a synonym for `sftlf` and `area` for `areacella` and check units on the later.

We provide an option for burnt area to be specified as a mean monthly rate in addition to a mean monthly state and provide code to compute the conversion.