### PR TITLE
Fix unit conversion

### DIFF
--- a/src/ILAMB/ilamblib.py
+++ b/src/ILAMB/ilamblib.py
@@ -1023,67 +1023,21 @@ def AnalysisMeanStateSites(ref,com,**keywords):
     skip_iav          = keywords.get("skip_iav"         ,False)
     skip_cycle        = keywords.get("skip_cycle"       ,False)
     ILAMBregions      = Regions()
-    spatial           = False
     normalizer        = None
 
     # Only study the annual cycle if it makes sense
     if    not ref.monthly: skip_cycle = True
     if ref.time.size < 12: skip_cycle = True
     if skip_rmse         : skip_iav   = True
-
-    if spatial:
-        lat,lon,lat_bnds,lon_bnds = _composeGrids(ref,com)
-        REF = ref.interpolate(lat=lat,lon=lon,lat_bnds=lat_bnds,lon_bnds=lon_bnds)
-        COM = com.interpolate(lat=lat,lon=lon,lat_bnds=lat_bnds,lon_bnds=lon_bnds)
-
+    
     # We find the mean values over the time period on the original
     # grid/datasites of each dataset
     ref_timeint = ref.integrateInTime(mean=True)
     com_timeint = com.integrateInTime(mean=True)
-    if spatial:
-
-        REF_timeint = REF.integrateInTime(mean=True)
-        COM_timeint = COM.integrateInTime(mean=True)
-
-        # Masks
-        ref_mask    = REF_timeint.data.mask
-        com_mask    = COM_timeint.data.mask
-        ref_and_com = (ref_mask == False) * (com_mask == False)
-        ref_not_com = (ref_mask == False) * (com_mask == True )
-        com_not_ref = (ref_mask == True ) * (com_mask == False)
-        ref_and_COM = Variable(name = "ref_and_COM", unit = ref.unit,
-                               data = np.ma.masked_array(COM_timeint.data,mask=(ref_and_com==False)),
-                               lat  = lat, lat_bnds = lat_bnds,
-                               lon  = lon, lon_bnds = lon_bnds,
-                               area = COM_timeint.area)
-        COM_not_ref = Variable(name = "COM_not_ref", unit = ref.unit,
-                               data = np.ma.masked_array(COM_timeint.data,mask=(com_not_ref==False)),
-                               lat  = lat, lat_bnds = lat_bnds,
-                               lon  = lon, lon_bnds = lon_bnds,
-                               area = COM_timeint.area)
-        REF_and_com = Variable(name = "REF_and_com", unit = REF.unit,
-                               data = np.ma.masked_array(REF_timeint.data,mask=(ref_and_com==False)),
-                               lat  = lat, lat_bnds = lat_bnds,
-                               lon  = lon, lon_bnds = lon_bnds,
-                               area = REF_timeint.area)
-        REF_not_com = Variable(name = "REF_not_com", unit = REF.unit,
-                               data = np.ma.masked_array(REF_timeint.data,mask=(ref_not_com==False)),
-                               lat  = lat, lat_bnds = lat_bnds,
-                               lon  = lon, lon_bnds = lon_bnds,
-                               area = REF_timeint.area)
-
-        # Apply intersection mask
-        REF.data.mask += np.ones(REF.time.size,dtype=bool)[:,np.newaxis,np.newaxis] * (ref_and_com==False)
-        COM.data.mask += np.ones(COM.time.size,dtype=bool)[:,np.newaxis,np.newaxis] * (ref_and_com==False)
-        REF_timeint.data.mask = (ref_and_com==False)
-        COM_timeint.data.mask = (ref_and_com==False)
-
-    else:
-
-        REF         = ref
-        COM         = com
-        REF_timeint = ref_timeint
-        COM_timeint = com_timeint
+    REF         = ref
+    COM         = com
+    REF_timeint = ref_timeint
+    COM_timeint = com_timeint
     if mass_weighting: normalizer = REF_timeint.data
 
     # Compute the bias, RMSE, and RMS maps using the interpolated
@@ -1097,8 +1051,6 @@ def AnalysisMeanStateSites(ref,com,**keywords):
                     area = REF.area, ndata     = REF.ndata)
     crms = cREF.rms ()
     bias_score_map = Score(bias,crms)
-    if spatial:
-        bias_score_map.data.mask = (ref_and_com==False) # for some reason I need to explicitly force the mask
     if not skip_rmse:
         cCOM = Variable(name = "centralized %s" % COM.name, unit = COM.unit,
                         data = np.ma.masked_array(COM.data-COM_timeint.data[np.newaxis,...],mask=COM.data.mask),
@@ -1159,53 +1111,26 @@ def AnalysisMeanStateSites(ref,com,**keywords):
     ref_union_mean = {}; ref_comp_mean = {}
     com_union_mean = {}; com_comp_mean = {}
     for region in regions:
-        if spatial:
-            ref_period_mean[region] = ref_timeint    .integrateInSpace(region=region,mean=space_mean)
-            ref_union_mean [region] = REF_and_com    .integrateInSpace(region=region,mean=space_mean)
-            com_union_mean [region] = ref_and_COM    .integrateInSpace(region=region,mean=space_mean)
-            ref_comp_mean  [region] = REF_not_com    .integrateInSpace(region=region,mean=space_mean)
-            com_comp_mean  [region] = COM_not_ref    .integrateInSpace(region=region,mean=space_mean)
-            ref_spaceint   [region] = REF            .integrateInSpace(region=region,mean=True)
-            com_period_mean[region] = com_timeint    .integrateInSpace(region=region,mean=space_mean)
-            com_spaceint   [region] = COM            .integrateInSpace(region=region,mean=True)
-            bias_val       [region] = bias           .integrateInSpace(region=region,mean=True)
-            bias_score     [region] = bias_score_map .integrateInSpace(region=region,mean=True,weight=normalizer)
-            if not skip_cycle:
-                ref_mean_cycle[region] = ref_cycle   .integrateInSpace(region=region,mean=True)
-                ref_dtcycle   [region] = deepcopy(ref_mean_cycle[region])
-                ref_dtcycle   [region].data -= ref_mean_cycle[region].data.mean()
-                com_mean_cycle[region] = com_cycle  .integrateInSpace(region=region,mean=True)
-                com_dtcycle   [region] = deepcopy(com_mean_cycle[region])
-                com_dtcycle   [region].data -= com_mean_cycle[region].data.mean()
-                shift         [region] = shift_map      .integrateInSpace(region=region,mean=True,intabs=True)
-                shift_score   [region] = shift_score_map.integrateInSpace(region=region,mean=True,weight=normalizer)
-            if not skip_rmse:
-                rmse_val   [region] = rmse           .integrateInSpace(region=region,mean=True)
-                rmse_score [region] = rmse_score_map .integrateInSpace(region=region,mean=True,weight=normalizer)
-            if not skip_iav:
-                iav_score  [region] = iav_score_map .integrateInSpace(region=region,mean=True,weight=normalizer)
-            space_std[region],space_cor[region],sd_score[region] = REF_timeint.spatialDistribution(COM_timeint,region=region)
-        else:
-            ref_period_mean[region] = ref_timeint    .siteStats(region=region)
-            ref_spaceint   [region] = ref            .siteStats(region=region)
-            com_period_mean[region] = com_timeint    .siteStats(region=region)
-            com_spaceint   [region] = com            .siteStats(region=region)
-            bias_val       [region] = bias           .siteStats(region=region)
-            bias_score     [region] = bias_score_map .siteStats(region=region,weight=normalizer)
-            if not skip_cycle:
-                ref_mean_cycle [region] = ref_cycle  .siteStats(region=region)
-                ref_dtcycle    [region] = deepcopy(ref_mean_cycle[region])
-                ref_dtcycle    [region].data -= ref_mean_cycle[region].data.mean()
-                com_mean_cycle [region] = com_cycle  .siteStats(region=region)
-                com_dtcycle    [region] = deepcopy(com_mean_cycle[region])
-                com_dtcycle    [region].data -= com_mean_cycle[region].data.mean()
-                shift          [region] = shift_map  .siteStats(region=region,intabs=True)
-                shift_score    [region] = shift_score_map.siteStats(region=region,weight=normalizer)
-            if not skip_rmse:
-                rmse_val   [region] = rmse           .siteStats(region=region)
-                rmse_score [region] = rmse_score_map .siteStats(region=region,weight=normalizer)
-            if not skip_iav:
-                iav_score  [region] = iav_score_map .siteStats(region=region,weight=normalizer)
+        ref_period_mean[region] = ref_timeint    .siteStats(region=region)
+        ref_spaceint   [region] = ref            .siteStats(region=region)
+        com_period_mean[region] = com_timeint    .siteStats(region=region)
+        com_spaceint   [region] = com            .siteStats(region=region)
+        bias_val       [region] = bias           .siteStats(region=region)
+        bias_score     [region] = bias_score_map .siteStats(region=region,weight=normalizer)
+        if not skip_cycle:
+            ref_mean_cycle [region] = ref_cycle  .siteStats(region=region)
+            ref_dtcycle    [region] = deepcopy(ref_mean_cycle[region])
+            ref_dtcycle    [region].data -= ref_mean_cycle[region].data.mean()
+            com_mean_cycle [region] = com_cycle  .siteStats(region=region)
+            com_dtcycle    [region] = deepcopy(com_mean_cycle[region])
+            com_dtcycle    [region].data -= com_mean_cycle[region].data.mean()
+            shift          [region] = shift_map  .siteStats(region=region,intabs=True)
+            shift_score    [region] = shift_score_map.siteStats(region=region,weight=normalizer)
+        if not skip_rmse:
+            rmse_val   [region] = rmse           .siteStats(region=region)
+            rmse_score [region] = rmse_score_map .siteStats(region=region,weight=normalizer)
+        if not skip_iav:
+            iav_score  [region] = iav_score_map .siteStats(region=region,weight=normalizer)
 
         ref_period_mean[region].name = "Period Mean (original grids) %s" % (region)
         ref_spaceint   [region].name = "spaceint_of_%s_over_%s"        % (ref.name,region)
@@ -1225,20 +1150,17 @@ def AnalysisMeanStateSites(ref,com,**keywords):
             com_dtcycle   [region].name = "dtcycle_of_%s_over_%s"         % (ref.name,region)
             shift         [region].name = "Phase Shift %s"                % (region)
             shift_score   [region].name = "Seasonal Cycle Score %s"       % (region)
-        if spatial:
-            ref_union_mean[region].name = "Benchmark Period Mean (intersection) %s" % (region)
-            com_union_mean[region].name = "Model Period Mean (intersection) %s"     % (region)
-            ref_comp_mean [region].name = "Benchmark Period Mean (complement) %s"   % (region)
-            com_comp_mean [region].name = "Model Period Mean (complement) %s"       % (region)
-            sd_score      [region].name = "Spatial Distribution Score %s"           % (region)
 
     # Unit conversions
     def _convert(var,unit):
         if type(var) == type({}):
             for key in var.keys(): var[key].convert(unit)
         else:
+            print(var)
             var.convert(unit)
-
+            print(var)
+            print("---------------------")
+            
     if table_unit is not None:
         for var in [ref_period_mean,com_period_mean,ref_union_mean,com_union_mean,ref_comp_mean,com_comp_mean]:
             _convert(var,table_unit)

--- a/src/ILAMB/ilamblib.py
+++ b/src/ILAMB/ilamblib.py
@@ -1154,12 +1154,9 @@ def AnalysisMeanStateSites(ref,com,**keywords):
     # Unit conversions
     def _convert(var,unit):
         if type(var) == type({}):
-            for key in var.keys(): var[key].convert(unit)
+            for key in var.keys(): var[key].convert(unit)                
         else:
-            print(var)
             var.convert(unit)
-            print(var)
-            print("---------------------")
             
     if table_unit is not None:
         for var in [ref_period_mean,com_period_mean,ref_union_mean,com_union_mean,ref_comp_mean,com_comp_mean]:


### PR DESCRIPTION
Unit conversion in ILAMB is bugged due to the unexpected behavior of `is_convertible()`. For example: 

```
In [1]: from cf_units import Unit                                                                                                                                            
In [2]: u = Unit('g')                                                                                                                                                        
In [3]: u.is_convertible("1/g") 
Out[3]: True
```
This produces unexpected results in very few cases in ILAMB runs and, as far as I know, is only an issue with the magnitude of period means that we report. This patch switches the logic when checking if we need to multiply or divide by density/molar mass to be definitive and fixes the error which initially brought this to my attention. Thanks Daniel Kennedy.
