### PR TITLE
WIP: CMEC compliance

### DIFF
--- a/bin/ilamb-run
+++ b/bin/ilamb-run
@@ -677,7 +677,9 @@ if not args.skip_plots:
     W = BuildLocalWorkList(M,C,skip_cache=False)
     WorkPost(M,C,W,S,not args.quiet)
 
-    if rank==0: S.createHtml(M)
+if rank==0:
+    S.createHtml(M)
+    S.createUDDashboard()
 
 sys.stdout.flush(); comm.Barrier()
 

--- a/bin/ilamb-run
+++ b/bin/ilamb-run
@@ -589,7 +589,6 @@ for key in run_opts:
         define_regions = [os.path.join(os.environ['ILAMB_ROOT'],r) for r in run_opts[key].split(",")]
         args.__dict__[key] += define_regions
 assert args.rmse_score_basis in ['series','cycle']
-if rank == 0: os.system("cp %s %s" % (args.config[0],os.path.join(args.build_dir[0],"ilamb.cfg")))
 
 # Setup regions
 r = Regions()
@@ -630,6 +629,7 @@ if len(args.study_limits) == 2:
     args.study_limits[1] += 1
     for c in C: c.study_limits = (np.asarray(args.study_limits)-1850)*365.
 Cf = FilterConfrontationList(C,args.confront)
+if rank == 0: os.system("cp %s %s" % (args.config[0],os.path.join(args.build_dir[0],"ilamb.cfg")))
 
 # Setup logging
 logger    = logging.getLogger("%i" % comm.rank)

--- a/bin/ilamb-run
+++ b/bin/ilamb-run
@@ -589,6 +589,7 @@ for key in run_opts:
         define_regions = [os.path.join(os.environ['ILAMB_ROOT'],r) for r in run_opts[key].split(",")]
         args.__dict__[key] += define_regions
 assert args.rmse_score_basis in ['series','cycle']
+if rank == 0: os.system("cp %s %s" % (args.config[0],os.path.join(args.build_dir[0],"ilamb.cfg")))
 
 # Setup regions
 r = Regions()

--- a/bin/ilamb-run
+++ b/bin/ilamb-run
@@ -137,12 +137,14 @@ def ParseModelSetup(model_setup,models=[],verbose=False,filter="",regex="",model
             mname      = None
             mdir       = None
             model_year = None
+            mgrp       = ""
             if len(line) >= 2:
                 mname  = line[0].strip()
                 mdir   = line[1].strip()
                 # if mdir not a directory, then maybe path is relative to ILAMB_ROOT
                 if not os.path.isdir(mdir):
                     mdir = os.path.join(os.environ["ILAMB_ROOT"],mdir).strip()
+                if len(line) == 3: mgrp = line[2].strip()
             if len(line) == 4:
                 model_year = [float(line[2].strip()),float(line[3].strip())]
             max_model_name_len = max(max_model_name_len,len(mname))
@@ -153,7 +155,7 @@ def ParseModelSetup(model_setup,models=[],verbose=False,filter="",regex="",model
                     m = pickle.load(infile)
             else:
                 try:
-                    m = ModelResult(mdir, modelname = mname, filter=filter, regex=regex, model_year = model_year)
+                    m = ModelResult(mdir, modelname = mname, filter=filter, regex=regex, model_year = model_year, group = mgrp)
                 except Exception as ex:
                     if log: logger.debug("[%s]" % mname,format_exc())
                     continue
@@ -696,7 +698,7 @@ if rank==0:
 
 if rank==0:
     S.dumpScores(M,"scores.csv")
-    S.harvestInformation()
+    S.harvestInformation(M)
     
 if (rank == 0              and
     ierr_reduced.max() > 0 and

--- a/ilamb-sysmpi.yml
+++ b/ilamb-sysmpi.yml
@@ -9,6 +9,7 @@ channels:
 dependencies:
   - python=3
   - numpy
+  - pandas
   - matplotlib
   - cartopy
   - netCDF4

--- a/ilamb.yml
+++ b/ilamb.yml
@@ -8,6 +8,7 @@ channels:
 dependencies:
   - python=3
   - numpy
+  - pandas
   - matplotlib
   - cartopy
   - netCDF4

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
              'bin/ilamb-setup'],
     zip_safe=False,
     install_requires=['numpy>=1.11.0',
+                      'pandas>=1.0.0',
                       'matplotlib>=2.2',
                       'cartopy>=0.17.0',
                       'netCDF4>=1.1.4',

--- a/src/ILAMB/ConfAlbedo.py
+++ b/src/ILAMB/ConfAlbedo.py
@@ -134,10 +134,12 @@ class ConfAlbedo(Confrontation):
             # Encode some names and colors
             fcm.mod_dset.setncatts({"name" :m.name,
                                     "color":m.color,
+                                    "weight":self.cweight,
                                     "complete":0})
             if self.master:
                 fcm.obs_dset.setncatts({"name" :"Benchmark",
                                         "color":np.asarray([0.5,0.5,0.5]),
+                                        "weight":self.cweight,
                                         "complete":0})
 
             # Read in some options and run the mean state analysis

--- a/src/ILAMB/ConfCO2.py
+++ b/src/ILAMB/ConfCO2.py
@@ -816,13 +816,13 @@ class ConfCO2(Confrontation):
 
         # Write out the intermediate variables
         with Dataset(os.path.join(self.output_path,"%s_%s.nc" % (self.name,m.name)),mode="w") as results:
-            results.setncatts({"name" :m.name, "color":m.color})
+            results.setncatts({"name" :m.name, "color":m.color, "weight":self.cweight})
             for v in [mod,mcyc,miav,mcycf,mod_maxp,mod_minp,mod_amp,Samp,Siav,Smax,Smin]:
                 v.toNetCDF4(results,group="MeanState")
             results.setncattr("complete",1)
         if not self.master: return
         with Dataset(os.path.join(self.output_path,"%s_Benchmark.nc" % self.name),mode="w") as results:
-            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5])})
+            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"weight":self.cweight})
             for v in [obs,ocyc,oiav,ocycf,obs_maxp,obs_minp,obs_amp]:
                 v.toNetCDF4(results,group="MeanState")
             results.setncattr("complete",1)

--- a/src/ILAMB/ConfDiurnal.py
+++ b/src/ILAMB/ConfDiurnal.py
@@ -252,7 +252,7 @@ class ConfDiurnal(Confrontation):
         Lmod = np.asarray(Lmod).mean()
 
         with Dataset(os.path.join(self.output_path,"%s_%s.nc" % (self.name,m.name)),mode="w") as results:
-            results.setncatts({"name" :m.name, "color":m.color})
+            results.setncatts({"name" :m.name, "color":m.color,"weight":self.cweight})
             Variable(name = "Season Length global",
                      unit = "d",
                      data = Lmod).toNetCDF4(results,group="MeanState")
@@ -293,7 +293,7 @@ class ConfDiurnal(Confrontation):
             results.setncattr("complete",1)
         if not self.master: return
         with Dataset(os.path.join(self.output_path,"%s_Benchmark.nc" % self.name),mode="w") as results:
-            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5])})
+            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]), "weight":self.cweight})
             Variable(name = "Season Length global",
                      unit = "d",
                      data = Lobs).toNetCDF4(results,group="MeanState")

--- a/src/ILAMB/ConfEvapFraction.py
+++ b/src/ILAMB/ConfEvapFraction.py
@@ -143,10 +143,12 @@ class ConfEvapFraction(Confrontation):
             # Encode some names and colors
             fcm.mod_dset.setncatts({"name" :m.name,
                                     "color":m.color,
+                                    "weight":self.cweight,                                    
                                     "complete":0})
             if self.master:
                 fcm.obs_dset.setncatts({"name" :"Benchmark",
                                         "color":np.asarray([0.5,0.5,0.5]),
+                                        "weight":self.cweight,
                                         "complete":0})
 
             # Read in some options and run the mean state analysis

--- a/src/ILAMB/ConfIOMB.py
+++ b/src/ILAMB/ConfIOMB.py
@@ -338,10 +338,12 @@ class ConfIOMB(Confrontation):
             # Encode some names and colors
             fcm.mod_dset.setncatts({"name" :m.name,
                                     "color":m.color,
+                                    "weight":self.cweight,
                                     "complete":0})
             if self.master:
                 fcm.obs_dset.setncatts({"name" :"Benchmark",
                                         "color":np.asarray([0.5,0.5,0.5]),
+                                        "weight":self.cweight,
                                         "complete":0})
 
             obs_timeint = {}; mod_timeint = {}

--- a/src/ILAMB/ConfNBP.py
+++ b/src/ILAMB/ConfNBP.py
@@ -97,7 +97,7 @@ class ConfNBP(Confrontation):
             obs    .name = "spaceint_of_nbp_over_global"
             obs_sum.name = "accumulate_of_nbp_over_global"
             with Dataset(os.path.join(self.output_path,"%s_Benchmark.nc" % (self.name)),mode="w") as results:
-                results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"complete":0})
+                results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"weight":self.cweight,"complete":0})
                 obs     .toNetCDF4(results,group="MeanState")
                 obs_sum .toNetCDF4(results,group="MeanState")
                 obs_end .toNetCDF4(results,group="MeanState")
@@ -164,7 +164,7 @@ class ConfNBP(Confrontation):
 
         # Dump to files
         results = Dataset(os.path.join(self.output_path,"%s_%s.nc" % (self.name,m.name)),mode="w")
-        results.setncatts({"name" :m.name, "color":m.color,"complete":0})
+        results.setncatts({"name" :m.name, "color":m.color,"weight":self.cweight,"complete":0})
         mod       .toNetCDF4(results,group="MeanState")
         mod_sum   .toNetCDF4(results,group="MeanState")
         mod_end   .toNetCDF4(results,group="MeanState")

--- a/src/ILAMB/ConfPermafrost.py
+++ b/src/ILAMB/ConfPermafrost.py
@@ -188,7 +188,7 @@ class ConfPermafrost(Confrontation):
         mod_not_obs_land_area.name = "Excess Area (Land Representation)"
 
         results = Dataset("%s/%s_%s.nc" % (self.output_path,self.name,m.name),mode="w")
-        results.setncatts({"name" :m.name, "color":m.color, "complete":0})
+        results.setncatts({"name" :m.name, "color":m.color, "complete":0, "weight":self.cweight})
         mod                  .toNetCDF4(results,group="MeanState")
         obs_and_mod          .toNetCDF4(results,group="MeanState")
         obs_not_mod          .toNetCDF4(results,group="MeanState")
@@ -206,7 +206,7 @@ class ConfPermafrost(Confrontation):
 
         if self.master:
             results = Dataset("%s/%s_Benchmark.nc" % (self.output_path,self.name),mode="w")
-            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"complete":0})
+            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"weight":self.cweight,"complete":0})
             obs_area.toNetCDF4(results,group="MeanState")
             results.setncattr("complete",1)
             results.close()

--- a/src/ILAMB/ConfRunoff.py
+++ b/src/ILAMB/ConfRunoff.py
@@ -163,7 +163,7 @@ class ConfRunoff(Confrontation):
 
         # Dump to files
         results = Dataset(os.path.join(self.output_path,"%s_%s.nc" % (self.name,m.name)),mode="w")
-        results.setncatts({"name" :m.name, "color":m.color,"complete":0})
+        results.setncatts({"name" :m.name, "color":m.color,"weight":self.cweight,"complete":0})
         for var in [mod,
                     mod_period_mean,
                     mod_timeint,
@@ -177,7 +177,7 @@ class ConfRunoff(Confrontation):
         results.close()
         if self.master:
             results = Dataset(os.path.join(self.output_path,"%s_Benchmark.nc" % self.name),mode="w")
-            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"complete":0})
+            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"weight":self.cweight,"complete":0})
             for var in [obs,
                         obs_period_mean,
                         obs_timeint]:

--- a/src/ILAMB/ConfSoilCarbon.py
+++ b/src/ILAMB/ConfSoilCarbon.py
@@ -138,7 +138,7 @@ class ConfSoilCarbon(Confrontation):
             plt.close()
     
             with Dataset("%s/%s_Benchmark.nc" % (self.output_path,self.name),mode="w") as results:
-                results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"complete":0})
+                results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"weight":self.cweight,"complete":0})
                 p = r.dist["default"][5]
                 Q10 = 10**(-10*(np.polyval(np.polyder(p),T10)))
                 for q,t in zip(Q10,T10):
@@ -172,7 +172,7 @@ class ConfSoilCarbon(Confrontation):
         plt.close()
         
         with Dataset("%s/%s_%s.nc" % (self.output_path,self.name,m.name),mode="w") as results:
-            results.setncatts({"name" :m.name, "color":m.color,"complete":0})
+            results.setncatts({"name" :m.name, "color":m.color,"weight":self.cweight,"complete":0})
             mod_p = mod_r.dist["default"][5]
             Q10 = 10**(-10*(np.polyval(np.polyder(mod_p),T10)))
             for q,t in zip(Q10,T10):

--- a/src/ILAMB/ConfTWSA.py
+++ b/src/ILAMB/ConfTWSA.py
@@ -167,7 +167,7 @@ class ConfTWSA(Confrontation):
 
         # dump results to a netCDF4 file
         results = Dataset(os.path.join(self.output_path,"%s_%s.nc" % (self.name,m.name)),mode="w")
-        results.setncatts({"name" :m.name, "color":m.color, "complete":0})
+        results.setncatts({"name" :m.name, "color":m.color, "weight":self.cweight,"complete":0})
         mod         .toNetCDF4(results,group="MeanState")
         mod_anom_val.toNetCDF4(results,group="MeanState")
         mod_anom_map.toNetCDF4(results,group="MeanState")
@@ -180,7 +180,7 @@ class ConfTWSA(Confrontation):
         results.close()
         if self.master:
             results = Dataset(os.path.join(self.output_path,"%s_Benchmark.nc" % (self.name)),mode="w")
-            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"complete":0})
+            results.setncatts({"name" :"Benchmark", "color":np.asarray([0.5,0.5,0.5]),"weight":self.cweight,"complete":0})
             obs.toNetCDF4(results,group="MeanState")
             obs_anom_val.toNetCDF4(results,group="MeanState")
             obs_anom_map.toNetCDF4(results,group="MeanState")

--- a/src/ILAMB/ConfUncertainty.py
+++ b/src/ILAMB/ConfUncertainty.py
@@ -225,10 +225,12 @@ class ConfUncertainty(Confrontation):
             # Encode some names and colors
             fcm.mod_dset.setncatts({"name" :m.name,
                                     "color":m.color,
+                                    "weight":self.cweight,
                                     "complete":0})
             if self.master:
                 fcm.obs_dset.setncatts({"name" :"Benchmark",
                                         "color":np.asarray([0.5,0.5,0.5]),
+                                        "weight":self.cweight,
                                         "complete":0})
             AnalysisUncertaintySpatial(ref,mod,dataset    = fcm.mod_dset,
                                        regions            = self.regions,

--- a/src/ILAMB/Confrontation.py
+++ b/src/ILAMB/Confrontation.py
@@ -1144,7 +1144,7 @@ class Confrontation(object):
                 # Analysis over regions
                 lim_dep  = [dep_min,dep_max]
                 lim_ind  = [ind_min,ind_max]
-                longname = c.longname.split('/')[0]
+                longname = c.longname.replace("/","|") # we want the source too, but netCDF doesn't like the '/'
                 for region in self.regions:
                     ref_dist = _buildDistributionResponse(ref_ind,ref_dep,ind_lim=lim_ind,dep_lim=lim_dep,region=region)
                     com_dist = _buildDistributionResponse(com_ind,com_dep,ind_lim=lim_ind,dep_lim=lim_dep,region=region)
@@ -1180,7 +1180,7 @@ class Confrontation(object):
 
                     # Score the functional response
                     score = _scoreFunction(ref_dist[3],com_dist[3])
-                    sname = "%s RMSE Score %s" % (longname,region)
+                    sname = "%s Score %s" % (longname,region)
                     if sname in scalars.variables:
                         scalars.variables[sname][0] = score
                     else:

--- a/src/ILAMB/Confrontation.py
+++ b/src/ILAMB/Confrontation.py
@@ -147,6 +147,7 @@ class Confrontation(object):
         self.keywords       = keywords
         self.extents        = np.asarray([[-90.,+90.],[-180.,+180.]])
         self.study_limits   = []
+        self.cweight         = 1
         
         # Make sure the source data exists
 
@@ -354,10 +355,12 @@ class Confrontation(object):
             # Encode some names and colors
             fcm.mod_dset.setncatts({"name" :m.name,
                                     "color":m.color,
+                                    "weight":self.cweight,
                                     "complete":0})
             if self.master:
                 fcm.obs_dset.setncatts({"name" :"Benchmark",
                                         "color":np.asarray([0.5,0.5,0.5]),
+                                        "weight":self.cweight,
                                         "complete":0})
 
             # Read in some options and run the mean state analysis

--- a/src/ILAMB/Post.py
+++ b/src/ILAMB/Post.py
@@ -1155,7 +1155,8 @@ def CreateJSON(csv_file):
     nest = {}
     for region in regions:
         name = r.getRegionName(region)
-        nest[region] = {"LongName":name,"Description":name,"Generator":""}
+        source = r.getRegionSource(region)
+        nest[region] = {"LongName":name,"Description":name,"Generator":source}
     out["DIMENSIONS"]["dimensions"]["region"] = nest
 
     # populate the models

--- a/src/ILAMB/Post.py
+++ b/src/ILAMB/Post.py
@@ -1096,7 +1096,7 @@ def RegisterCustomColormaps():
     plt.register_cmap("wetdry",cm)                                                    
 
 def HarvestScalarDatabase(build_dir,filename="scalar_database.csv"):
-    csv = "Section,Variable,Source,Model,ScalarName,AnalysisType,Region,ScalarType,Units,Data,Weight"
+    csv = '"Section","Variable","Source","Model","ScalarName","AnalysisType","Region","ScalarType","Units","Data","Weight"'
     for root,subdirs,files in os.walk(build_dir):
         for fname in files:
             if not fname.endswith(".nc"): continue
@@ -1120,7 +1120,7 @@ def HarvestScalarDatabase(build_dir,filename="scalar_database.csv"):
                             v = grp.variables[vname]
                             V = v[...]
                             s = "nan" if V.mask else "%g" % V
-                            csv += "\n%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" % (category,varname,provider,model,var,g1,region,stype,v.units,s,weight)
+                            csv += "\n" + ",".join(['"%s"' % v for v in (category,varname,provider,model,var,g1,region,stype,v.units,s,weight)])
     with open(os.path.join(build_dir,filename),mode="w") as f: f.write(csv)
 
 def CreateJSON(csv_file):

--- a/src/ILAMB/Post.py
+++ b/src/ILAMB/Post.py
@@ -1149,8 +1149,8 @@ def CreateJSON(csv_file,M=None):
             if qs.shape[0] > 0: scores[_unCamelCase(s)] = _weightedMean(qs)
         return scores
 
-    df = pd.read_csv(csv_file)
-    df = df.query("ScalarType=='score'")
+    # Drop nan's and we only need the scores from the database
+    df = pd.read_csv(csv_file).dropna().query("ScalarType=='score'")
     models = list(df.Model.unique())
     r = Regions()
     regions = [n for n in df.Region.unique() if n in r.regions]
@@ -1262,8 +1262,7 @@ def CreateJSON(csv_file,M=None):
                     for d in D:
                         dd = "%s!!%s" % (vv,_unCamelCase(d))
                         q = df_m.query("Variable=='%s' & ScalarName=='%s RMSE Score'" % (v,d))
-                        assert len(q)==1
-                        nest[region][m][dd] = {"Overall Score":q.Data.mean()}                     
+                        nest[region][m][dd] = {"Overall Score":_weightedMean(q)}                     
     out["RESULTS"] = nest
 
     with open(csv_file.replace(".csv",".json"), 'w') as outfile:

--- a/src/ILAMB/Post.py
+++ b/src/ILAMB/Post.py
@@ -1123,7 +1123,7 @@ def HarvestScalarDatabase(build_dir,filename="scalar_database.csv"):
                             csv += "\n" + ",".join(['"%s"' % v for v in (category,varname,provider,model,var,g1,region,stype,v.units,s,weight)])
     with open(os.path.join(build_dir,filename),mode="w") as f: f.write(csv)
 
-def CreateJSON(csv_file):
+def CreateJSON(csv_file,M):
     """Using the CSV scalar database, create a JSON following the CMEC standard.
     """
     def _unCamelCase(s): return re.sub("([a-z])([A-Z])","\g<1> \g<2>",s)
@@ -1162,7 +1162,10 @@ def CreateJSON(csv_file):
     # populate the models
     nest = {}
     for model in models:
-        nest[model] = {"Description":"","Source":""}
+        m = [m for m in M if m.name == model]
+        assert len(m) == 1
+        m = m[0]
+        nest[model] = {"Description":m.description,"Source":m.group}
     out["DIMENSIONS"]["dimensions"]["model"] = nest
 
     # populate the list of metrics

--- a/src/ILAMB/Regions.py
+++ b/src/ILAMB/Regions.py
@@ -1,3 +1,4 @@
+import os
 from netCDF4 import Dataset
 import numpy as np
 
@@ -12,13 +13,14 @@ class Regions(object):
 
     """
     _regions = {}
-
+    _sources = {}
+    
     @property
     def regions(self):
         """Returns a list of region identifiers."""
         return Regions._regions.keys()
-
-    def addRegionLatLonBounds(self,label,name,lats,lons):
+    
+    def addRegionLatLonBounds(self,label,name,lats,lons,source="user-provided latlon bounds"):
         """Add a region by lat/lon bounds.
 
         Parameters
@@ -31,7 +33,8 @@ class Regions(object):
             the minimum and maximum latitudes defining the region on the interval (-90,90)
         lons : array-like of size 2
             the minimum and maximum longitudes defining the region on the interval (-180,180)
-
+        source : str, optional
+            a string representing the source of the region, purely cosmetic
         """
         lat  = np.hstack([[- 90.],np.asarray(lats),[ 90.]])
         lon  = np.hstack([[-180.],np.asarray(lons),[180.]])
@@ -39,7 +42,8 @@ class Regions(object):
                            [1,0,1],
                            [1,1,1]],dtype=bool)
         Regions._regions[label] = [name,lat,lon,mask]
-
+        Regions._sources[label] = source
+        
     def addRegionNetCDF4(self,filename):
         """Add regions found in a netCDF4 file.
 
@@ -103,6 +107,7 @@ class Regions(object):
                     name  = nam[i]
                     mask  = v[...].data != i
                     Regions._regions[label] = [name,lat,lon,mask]
+                    Regions._sources[label] = os.path.basename(filename)
                     labels.append(label)
         return labels
 
@@ -120,6 +125,21 @@ class Regions(object):
             the long name of the region
         """
         return Regions._regions[label][0]
+    
+    def getRegionSource(self,label):
+        """Given the region label, return the source.
+
+        Parameters
+        ----------
+        label : str
+            the unique region identifier
+
+        Returns
+        -------
+        name : str
+            the source of the region
+        """
+        return Regions._sources[label]
 
     def getMask(self,label,var):
         """Given the region label and a ILAMB.Variable, return a mask appropriate for that variable.
@@ -178,23 +198,25 @@ if "global" not in Regions().regions:
 
     # Populate some regions
     r = Regions()
-    r.addRegionLatLonBounds("global","Globe",(-89.999, 89.999),(-179.999, 179.999))
+    src = "ILAMB internal"
+    r.addRegionLatLonBounds("global","Globe",(-89.999, 89.999),(-179.999, 179.999),src)
     Regions._regions["global"][3][...] = 0. # ensure global mask is null
-    r.addRegionLatLonBounds("globe","Global - All",(-89.999, 89.999),(-179.999, 179.999))
+    r.addRegionLatLonBounds("globe","Global - All",(-89.999, 89.999),(-179.999, 179.999),src)
     Regions._regions["globe"][3][...] = 0. # ensure global mask is null
 
     # GFED regions
-    r.addRegionLatLonBounds("bona","Boreal North America",             ( 49.75, 79.75),(-170.25,- 60.25))
-    r.addRegionLatLonBounds("tena","Temperate North America",          ( 30.25, 49.75),(-125.25,- 66.25))
-    r.addRegionLatLonBounds("ceam","Central America",                  (  9.75, 30.25),(-115.25,- 80.25))
-    r.addRegionLatLonBounds("nhsa","Northern Hemisphere South America",(  0.25, 12.75),(- 80.25,- 50.25))
-    r.addRegionLatLonBounds("shsa","Southern Hemisphere South America",(-59.75,  0.25),(- 80.25,- 33.25))
-    r.addRegionLatLonBounds("euro","Europe",                           ( 35.25, 70.25),(- 10.25,  30.25))
-    r.addRegionLatLonBounds("mide","Middle East",                      ( 20.25, 40.25),(- 10.25,  60.25))
-    r.addRegionLatLonBounds("nhaf","Northern Hemisphere Africa",       (  0.25, 20.25),(- 20.25,  45.25))
-    r.addRegionLatLonBounds("shaf","Southern Hemisphere Africa",       (-34.75,  0.25),(  10.25,  45.25))
-    r.addRegionLatLonBounds("boas","Boreal Asia",                      ( 54.75, 70.25),(  30.25, 179.75))
-    r.addRegionLatLonBounds("ceas","Central Asia",                     ( 30.25, 54.75),(  30.25, 142.58))
-    r.addRegionLatLonBounds("seas","Southeast Asia",                   (  5.25, 30.25),(  65.25, 120.25))
-    r.addRegionLatLonBounds("eqas","Equatorial Asia",                  (-10.25, 10.25),(  99.75, 150.25))
-    r.addRegionLatLonBounds("aust","Australia",                        (-41.25,-10.50),( 112.00, 154.00))
+    src = "Global Fire Emissions Database (GFED)"
+    r.addRegionLatLonBounds("bona","Boreal North America",             ( 49.75, 79.75),(-170.25,- 60.25),src)
+    r.addRegionLatLonBounds("tena","Temperate North America",          ( 30.25, 49.75),(-125.25,- 66.25),src)
+    r.addRegionLatLonBounds("ceam","Central America",                  (  9.75, 30.25),(-115.25,- 80.25),src)
+    r.addRegionLatLonBounds("nhsa","Northern Hemisphere South America",(  0.25, 12.75),(- 80.25,- 50.25),src)
+    r.addRegionLatLonBounds("shsa","Southern Hemisphere South America",(-59.75,  0.25),(- 80.25,- 33.25),src)
+    r.addRegionLatLonBounds("euro","Europe",                           ( 35.25, 70.25),(- 10.25,  30.25),src)
+    r.addRegionLatLonBounds("mide","Middle East",                      ( 20.25, 40.25),(- 10.25,  60.25),src)
+    r.addRegionLatLonBounds("nhaf","Northern Hemisphere Africa",       (  0.25, 20.25),(- 20.25,  45.25),src)
+    r.addRegionLatLonBounds("shaf","Southern Hemisphere Africa",       (-34.75,  0.25),(  10.25,  45.25),src)
+    r.addRegionLatLonBounds("boas","Boreal Asia",                      ( 54.75, 70.25),(  30.25, 179.75),src)
+    r.addRegionLatLonBounds("ceas","Central Asia",                     ( 30.25, 54.75),(  30.25, 142.58),src)
+    r.addRegionLatLonBounds("seas","Southeast Asia",                   (  5.25, 30.25),(  65.25, 120.25),src)
+    r.addRegionLatLonBounds("eqas","Equatorial Asia",                  (-10.25, 10.25),(  99.75, 150.25),src)
+    r.addRegionLatLonBounds("aust","Australia",                        (-41.25,-10.50),( 112.00, 154.00),src)

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -760,8 +760,8 @@ class Scoreboard():
 <html lang="en">
 <head>
    <meta charset="utf-8" />
-   <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/climatemodeling/unified-dashboard@lmtUDConfig/dist/js/lmtud_bundle.min.js"></script>
-   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/climatemodeling/unified-dashboard@lmtUDConfig/dist/css/lmtud_bundle.min.css">
+   <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/climatemodeling/unified-dashboard@1.0.0/dist/js/lmtud_bundle.min.js"></script>
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/climatemodeling/unified-dashboard@1.0.0/dist/css/lmtud_bundle.min.css">
 </head>
 <body>
     <nav id="menu" class="menu">

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -340,6 +340,7 @@ class Scoreboard():
                 node.source = os.path.join(os.environ["ILAMB_ROOT"],node.source if node.source else "")
                 node.mem_slab = mem_per_pair*0.5
                 node.confrontation = Constructor(**(node.__dict__))
+                node.confrontation.cweight = node.weight*node.parent.weight
                 node.confrontation.extents = extents
 
                 if verbose and master: print(("    {0:>%d}\033[92m Initialized\033[0m" % max_name_len).format(node.confrontation.longname))

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -754,6 +754,180 @@ class Scoreboard():
         HarvestScalarDatabase(self.build_dir)
         CreateJSON(os.path.join(self.build_dir,"scalar_database.csv"),M)
 
+    def createUDDashboard(self,filename="dashboard.html"):
+        html = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+   <meta charset="utf-8" />
+   <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/climatemodeling/unified-dashboard@lmtUDConfig/dist/js/lmtud_bundle.min.js"></script>
+   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/climatemodeling/unified-dashboard@lmtUDConfig/dist/css/lmtud_bundle.min.css">
+</head>
+<body>
+    <nav id="menu" class="menu">
+      <a href="https://www.bgc-feedbacks.org" target="_blank">
+        <header class="menu-header">
+          <span class="menu-header-title">Settings</span>
+        </header>
+      </a>
+      <section class="menu-section">
+         <div id="ck-button">
+             <label>
+                <input type="checkbox" name="colorblind" id="colorblind" class="mybtn" onchange="tableColor()" checked="true"><span>Colorblind colors</span>
+             </label>
+         </div>
+      </section>
+      <section class="menu-section">
+          <select class="hide-list" id="hlist" name="states[]" multiple="multiple" style="width:75%"> </select>
+      </section>
+      <section class="menu-section">
+          <select class="select-choice-x" id="select-choice-mini-x" style="width:75%"> <option></option></select>
+          <select class="select-choice-y" id="select-choice-mini-y" style="width:75%"> <option></option></select>
+      </section>
+      <section class="menu-section">
+          <select class="select-choice-1" id="select-choice-mini-0" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-2" id="select-choice-mini-1" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-3" id="select-choice-mini-2" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-4" id="select-choice-mini-3" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-5" id="select-choice-mini-4" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-6" id="select-choice-mini-5" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-7" id="select-choice-mini-6" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-8" id="select-choice-mini-7" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-9" id="select-choice-mini-8" style="width:75%; display:none"> <option></option></select>
+          <select class="select-choice-9" id="select-choice-mini-9" style="width:75%; display:none"> <option></option></select>
+      </section>
+      <section class="menu-section">
+          <h3 class="menu-section-title">Scaling</h3>
+          <label class="el-checkbox el-checkbox-sm">
+             <span class="margin-r">Row</span>
+             <input type="checkbox" class="scarow" value='scarow' id="checkboxsca" checked>
+             <span class="el-checkbox-style  pull-right"></span>
+          </label>
+          <label class="el-checkbox el-checkbox-sm">
+             <span class="margin-r">Column</span>
+             <input type="checkbox" class="scacol" value='scacol' id="checkboxsca">
+             <span class="el-checkbox-style  pull-right"></span>
+          </label>
+          <select class="select-choice-sca" id="select-choice-mini-sca" style="width:75%"> 
+             <option value="0" selected> Not normalized </option>
+             <option value="1"> Normalized [x-mean(x)]/sigma(x) </option>
+             <option value="2"> Normalized [-1:1] </option>
+             <option value="3"> Normalized [ 0:1] </option>
+          </select>
+          <select class="select-choice-map" id="select-choice-mini-map" style="width:75%"> 
+             <option value="0" selected> ILAMB color mapping </option>
+             <option value="1"> Linear color mapping </option>
+             <option value="2"> Linear color mapping reverse </option>
+          </select>
+      </section>
+      <hr>
+      <section class="menu-section">
+          <h3 class="menu-section-title">Examples</h3>
+          <select class="select-choice-ex" id="select-choice-mini-ex" style="width:75%"> 
+             <option value="cmec_ilamb_example_addsource.json"> CMEC ILAMB</option>
+             <option value="pmp_enso_tel.json"> CMEC PMP</option>
+          </select>
+          <h3 class="menu-section-title">Logo</h3>
+          <select class="select-choice-logo" id="select-choice-mini-logo" style="width:75%"> 
+             <option value="rubisco_logo.png"> RUBISCO</option>
+             <option value="cmec_logo.png"> CMEC</option>
+             <option value="pmp_logo.png"> PMP</option>
+             <option value="lmt-logo.png"> LMT</option>
+          </select>
+      </section>
+      <section class="menu-section">
+          <h3 class="menu-section-title">Switch</h3>
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="tooltips" onchange="toggleTooltips(true)" checked hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Tooltips</span>
+          </label>
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="cellvalue" onchange="toggleCellValue(true)" hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Cell Value</span>
+          </label>
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="bottomtitle" onchange="toggleBottomTitle(true)" hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Bottom Title</span>
+          </label>
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" id="toptitle" onchange="toggleTopTitle(true)" checked hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Top Title</span>
+          </label>
+          <label class="el-switch el-switch-sm">
+              <input type="checkbox" name="switch" class="screenheight" id="screenheight" onchange="toggleScreenHeight(true)" checked hidden>
+              <span class="el-switch-style"></span>
+              <span class="margin-r">Screen Height</span>
+          </label>
+      </section>
+      <hr>
+      <section class="menu-section">
+          <button type="button" onclick="expandCollapse('expand');" class="togglebutton">Row Expand/Collapse</button>
+      </section>
+      <hr>
+      <section class="menu-section">
+          <button type="button" onclick="savetoHtml();" class="togglebutton">Save to Html</button>
+      </section>
+    </nav>
+    <main id="panel" class="panel">
+      <header class="panel-header">
+        <!--button class="btn-hamburger js-slideout-toggle"></button-->
+        <span id="sidemenuicon" class="js-slideout-toggle">&#9776&nbsp;Menu</span>
+        <h1 class="title">LMT Unified Dashboard</h1>
+      </header>
+      <section style="text-align:center">
+        <input name="file" id="file" type="file" onchange="loadlocJson()"/> 
+      </section>
+      <section>
+        <div class="tabDiv" id="mytab">
+          <div id="dashboard-table"></div>
+        </div>
+        <center>
+            <div class="legDiv">
+            <p>Relative Scale
+            <table class="table-header-rotated" id="scoresLegend">
+              <tbody>
+                <tr>
+                  <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+                </tr>
+              </tbody>
+            </table>
+            Worse Value&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Better Value
+            <table class="table-header-rotated" id="missingLegend">
+              <tbody>
+                <tr>
+                  <td bgcolor="#808080"></td>
+                </tr>
+              </tbody>
+            </table>Missing Data or Error
+            </div>
+        </center>
+      </section>
+    </main>
+</body>
+</html>"""
+        with open(os.path.join(self.build_dir,filename           ),"w") as f: f.write(html)
+        with open(os.path.join(self.build_dir,"_lmtUDConfig.json"),'w') as f:
+            json.dump({
+                "udcJsonLoc": "scalar_database.json",
+                "udcDimSets": {
+                    "x_dim": "model",
+                    "y_dim": "metric",
+                    "fxdim": {
+                        "region": "global",
+                        "statistic": "Overall Score"
+                    }
+                },
+                "udcScreenHeight": 0,
+                "udcCellValue": 0,
+                "logofile": "None"
+            },f)
+        
+
+        
 def GenerateRelationshipTree(S,M):
 
     # Create a tree which mimics the scoreboard for relationships, but

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -539,7 +539,7 @@ class Scoreboard():
 		  for(let v in H2){
 	              var s_name = scalar_name;
                       if(h1 == "Relationships") {
-                        s_name = v.substring(0,v.indexOf("/")) + " RMSE Score " + region_option.options[region_option.selectedIndex].value;
+                        s_name = v.substring(0,v.indexOf("/")) + " Score " + region_option.options[region_option.selectedIndex].value;
                       }else{
                       }
 		      printRow(table,row,H2[v][s_name],cmap);

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -16,7 +16,7 @@ from .Regions import Regions
 import os,re
 from netCDF4 import Dataset
 import numpy as np
-from .Post import HarvestScalarDatabase
+from .Post import HarvestScalarDatabase,CreateJSON
 from .ilamblib import MisplacedData
 import glob,json
 
@@ -751,7 +751,8 @@ class Scoreboard():
 
     def harvestInformation(self):
         HarvestScalarDatabase(self.build_dir)
-        
+        CreateJSON(os.path.join(self.build_dir,"scalar_database.csv"))
+
 def GenerateRelationshipTree(S,M):
 
     # Create a tree which mimics the scoreboard for relationships, but

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -220,7 +220,7 @@ def BuildScalars(node):
         files = [f for f in glob.glob(os.path.join(node.output_path,"*.nc")) if "Benchmark" not in f]
         for fname in files:
             with Dataset(fname) as dset:
-                if dset.name not in models: continue
+                if dset.getncattr("name") not in models: continue
                 if section not in dset.groups: continue
                 grp = dset.groups[section]["scalars"]
                 scores = [c for c in grp.variables.keys() if "Score" in c]
@@ -228,7 +228,7 @@ def BuildScalars(node):
                 for c in scores:
                     if c not in s.keys():
                         s[c] = np.ma.masked_array(np.zeros(len(models)),mask=np.ones(len(models),dtype=bool))
-                    s[c][models.index(dset.name)] = grp[c][...]
+                    s[c][models.index(dset.getncattr("name"))] = grp[c][...]
     else:
         scores = None
         for child in node.children:

--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -750,9 +750,9 @@ class Scoreboard():
                     except:
                         out.write("%s,%s\n" % (v.name,','.join(["~"]*len(M))))
 
-    def harvestInformation(self):
+    def harvestInformation(self,M):
         HarvestScalarDatabase(self.build_dir)
-        CreateJSON(os.path.join(self.build_dir,"scalar_database.csv"))
+        CreateJSON(os.path.join(self.build_dir,"scalar_database.csv"),M)
 
 def GenerateRelationshipTree(S,M):
 


### PR DESCRIPTION
This patch will allow ILAMB to generate JSON files for scalars which are CMEC-compliant as well as introduces an alternative front page which uses the [LMT Unified Dashboard](https://github.com/climatemodeling/unified-dashboard). 

- [x] create a routine which harvests the information from the csv database using `pandas`, test with [online](https://lmt.ornl.gov/unified-dashboard) LMT Dashboard
- [x] add relationship-related scores to the JSON
- [x] add the dataset weights to the csv output so correct weighted averages may be taken
- [x] fix HarvestScalarDatabase which currently has an issue is there is a `,` in the name of a scalar
- [x] the region `generator` tag is blank, could populate if I store the source file name along with the region
- [x] the model `description` and `source` is blank, could populate by adding data to ModelResult, possibly auto-harvested from global attributes found in a representative file
- [x] implement a basic model description / group functionality. Both are strings that can be specified at the time of the constructor. If no description is specified, then I will try to harvest it using the `source_id` and `experiment_id` global attributes if present. Groups can be defined by adding a 3rd column to the `--model_setup` file specifying the text name desired.
- [x] when computing means, test the effect of `nan`. If needed use `pandas.dropna()`
- [x] Create a new HTML file in the spirit of the LMT UD and provide it as an optional view as `index_cmec.html`
- [x] run a test on the CMIP5v6 comparison so we have a more intricate file to inspect
