### PR TITLE
Fixes for CMEC operation

### DIFF
--- a/cmec-driver/cmip.json
+++ b/cmec-driver/cmip.json
@@ -187,11 +187,6 @@
       "long_name": "Forest Biomass",
       "description": "This product was derived from Forest Biomass across the Lower 48 States and Alaska originally in a raster format at 250m."
     },
-    "Thurner": {
-      "version": "2010",
-      "long_name": "Max Planck Institute regridded 30N-80N forest biomass",
-      "description": "Retrievals from synthetic aperture radar data using existing databases of wood density and allometric relationships between biomass compartments"
-    },
     "NOAA.Emulated": {
       "version": "Randerson and Mu 2016",
       "long_name": "derived NOAA GMD Site Observations",
@@ -360,13 +355,6 @@
             "table_unit": "Pg",
             "plot_unit": "kg m-2",
             "space_mean": true
-          },
-          "Thurner": {
-            "source": "DATA/biomass/Thurner/biomass_0.5x0.5.nc",
-            "weight": 15.0,
-            "table_unit": "Pg",
-            "plot_unit": "kg m-2",
-            "space_mean": true
           }
         },
         "Carbon Dioxide": {
@@ -386,7 +374,7 @@
           "cmap": "Greens",
           "weight": 5.0,
           "mass_weighting": true,
-          "FLUXNET2015": {
+          "FLUXNET": {
             "source": "DATA/gpp/FLUXNET2015/gpp.nc",
             "weight": 9.0,
             "table_unit": "g m-2 d-1",

--- a/cmec-driver/cmip.sh
+++ b/cmec-driver/cmip.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+source $CONDA_SOURCE
+conda activate $CONDA_ENV_ROOT/ilamb
+
 python $CMEC_CODE_DIR/parse_config.py "ILAMB/CMIP"

--- a/cmec-driver/custom_config.json
+++ b/cmec-driver/custom_config.json
@@ -20,7 +20,7 @@
     "any": {
       "version": "any",
       "long_name": "any observation",
-      "description": "Any obs avialable in CMIP configuration"
+      "description": "Any obs available in CMIP configuration"
     }
   },
   "coordinates": {

--- a/cmec-driver/custom_config.sh
+++ b/cmec-driver/custom_config.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+source $CONDA_SOURCE
+conda activate $CONDA_ENV_ROOT/ilamb
+
 python $CMEC_CODE_DIR/parse_config.py "ILAMB/Custom"

--- a/cmec-driver/diurnal.sh
+++ b/cmec-driver/diurnal.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+source $CONDA_SOURCE
+conda activate $CONDA_ENV_ROOT/ilamb
+
 python $CMEC_CODE_DIR/parse_config.py "ILAMB/Diurnal"

--- a/cmec-driver/forcings.json
+++ b/cmec-driver/forcings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "name": "forcings",
+        "name": "Forcings",
         "driver": "cmec-driver/forcings.sh",
         "async": "MPI",
         "long_name": "Forcings",
@@ -8,22 +8,32 @@
         "runtime": {"ILAMB": 2.6}
     },
     "varlist": {
-        "": {
-            "long_name": "",
-            "units": "",
-            "frequency": ""
+        "tas": {
+          "long_name": "Surface Air Temperature",
+          "units": "K",
+          "frequency": "mon"
+        },
+        "pr": {
+            "long_name": "Precipitation",
+            "units": "kg m-2 s-1",
+            "frequency": "mon"
         }
     },
     "obslist": {
-        "": {
-            "version": "",
-            "long_name": "",
-            "description": ""
+        "CRU4.02": {
+            "version": "4.02",
+            "long_name": "CRU time series (TS) high-resolution gridded datasets",
+            "description": "monthly observations at meteorological stations across the world land areas"
+        },
+        "GPCPv2.3": {
+            "version": "2.3",
+            "long_name": "GPCP Version 2.3 Combined Precipitation Dataset (Final)",
+            "description": "GPCC gauge analysis to bias correct satellite estimates over land and merge with satellite based on sampling"
         }
     },
     "coordinates": {
-        "max_time_range": "",
-        "min_time_range": ""
+        "max_time_range": "year",
+        "min_time_range": "mon"
     },
     "default_parameters": {
         "cfg": {

--- a/cmec-driver/forcings.sh
+++ b/cmec-driver/forcings.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-python $CMEC_CODE_DIR/parse_config.py "ILAMB/forcings"
+source $CONDA_SOURCE
+conda activate $CONDA_ENV_ROOT/ilamb
+
+python $CMEC_CODE_DIR/parse_config.py "ILAMB/Forcings"

--- a/cmec-driver/ilamb.sh
+++ b/cmec-driver/ilamb.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+source $CONDA_SOURCE
+conda activate $CONDA_ENV_ROOT/ilamb
+
 python $CMEC_CODE_DIR/parse_config.py "ILAMB/ILAMB"

--- a/cmec-driver/iomb.sh
+++ b/cmec-driver/iomb.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+source $CONDA_SOURCE
+conda activate $CONDA_ENV_ROOT/ilamb
+
 python $CMEC_CODE_DIR/parse_config.py "ILAMB/IOMB"

--- a/cmec-driver/parse_config.py
+++ b/cmec-driver/parse_config.py
@@ -66,8 +66,13 @@ if __name__ == '__main__':
 
     if custom_keys is not None:
         # load cmip config
-        with open(code_dir + "/cmip.json","r") as cf:
-            cmip = json.load(cf)["default_parameters"]["cfg"]
+        try:
+            cmip = cfdict["ILAMB/CMIP"]["cfg"]
+        except KeyError:
+            print("ILAMB/CMIP settings missing from cmec.json.")
+            print("Loading CMIP obs information from ILAMB/cmec-driver/cmip.json.")
+            with open(code_dir + "/cmip.json","r") as cf:
+                cmip = cfdict["ILAMB/CMIP"]["cfg"]
         # Might need to initialize config dictionary if using custom
         if "cfg" not in cfdict:
             cfdict["cfg"] = {}

--- a/cmec-driver/parse_config.py
+++ b/cmec-driver/parse_config.py
@@ -54,7 +54,6 @@ if __name__ == '__main__':
     config_file = config_dir + "/cmec.json"
     try:
         with open(config_file) as cf:
-            print(config_file)
             cfdict = json.load(cf)[module]
     except json.decoder.JSONDecodeError:
         print("Error: could not read " + config_file + ". File might not be valid JSON.")
@@ -67,7 +66,8 @@ if __name__ == '__main__':
     if custom_keys is not None:
         # load cmip config
         try:
-            cmip = cfdict["ILAMB/CMIP"]["cfg"]
+            with open(config_file) as cf:
+                cmip = json.load(cf)["ILAMB/CMIP"]["cfg"]
         except KeyError:
             print("ILAMB/CMIP settings missing from cmec.json.")
             print("Loading CMIP obs information from ILAMB/cmec-driver/cmip.json.")

--- a/cmec-driver/parse_config.py
+++ b/cmec-driver/parse_config.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             print("ILAMB/CMIP settings missing from cmec.json.")
             print("Loading CMIP obs information from ILAMB/cmec-driver/cmip.json.")
             with open(code_dir + "/cmip.json","r") as cf:
-                cmip = cf["default_parameters"]["cfg"]
+                cmip = json.load(cf)["default_parameters"]["cfg"]
         # Might need to initialize config dictionary if using custom
         if "cfg" not in cfdict:
             cfdict["cfg"] = {}

--- a/cmec-driver/parse_config.py
+++ b/cmec-driver/parse_config.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
             print("ILAMB/CMIP settings missing from cmec.json.")
             print("Loading CMIP obs information from ILAMB/cmec-driver/cmip.json.")
             with open(code_dir + "/cmip.json","r") as cf:
-                cmip = cfdict["ILAMB/CMIP"]["cfg"]
+                cmip = cf["default_parameters"]["cfg"]
         # Might need to initialize config dictionary if using custom
         if "cfg" not in cfdict:
             cfdict["cfg"] = {}

--- a/cmec-driver/parse_config.py
+++ b/cmec-driver/parse_config.py
@@ -61,7 +61,6 @@ if __name__ == '__main__':
 
     # Load CMIP confrontation info for custom configuration
     custom_keys = cfdict.pop("confrontations",None)
-    print(custom_keys)
 
     if custom_keys is not None:
         # load cmip config

--- a/cmec-driver/sample.sh
+++ b/cmec-driver/sample.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+source $CONDA_SOURCE
+conda activate $CONDA_ENV_ROOT/ilamb
+
 python $CMEC_CODE_DIR/parse_config.py "ILAMB/Sample"

--- a/contents.json
+++ b/contents.json
@@ -8,6 +8,7 @@
     "contents": [
         "cmec-driver/cmip.json",
         "cmec-driver/custom_config.json",
+        "cmec-driver/forcings.json",
         "cmec-driver/iomb.json",
         "cmec-driver/sample.json",
         "cmec-driver/ilamb.json"


### PR DESCRIPTION
This PR includes changes to improve running ILAMB via cmec-driver. There is one piece of new functionality (activating an ILAMB conda environment) and two fixes.

1. Activates the "ilamb" conda environment in the driver scripts (cmec/*.sh)
2. The "Custom" configuration checks the cmec settings JSON for obs information first, then checks the hard-coded information in cmip.json as a backup.
3. The "Forcings" configuration is now properly set up.