### PR TITLE
Compare layered datasets with standard ILAMB methodology

### DIFF
--- a/src/ILAMB/Confrontation.py
+++ b/src/ILAMB/Confrontation.py
@@ -293,6 +293,11 @@ class Confrontation(object):
         if obs.time is None: raise il.NotTemporalVariable()
         self.pruneRegions(obs)
 
+        # The reference might be layered and we want to extract a
+        # slice to compare against models
+        if "depth" in self.keywords and obs.layered:
+            obs.trim(d=[self.keywords['depth']-0.01,self.keywords['depth']+0.01])
+        
         # Try to extract a commensurate quantity from the model
         mod = m.extractTimeSeries(self.variable,
                                   alt_vars     = self.alternate_vars,


### PR DESCRIPTION
With this PR, `h2` headings in the ILAMB configure files now allow the `depths` keyword which will accept a float or comma delimited list of floats (e.g. `depths = 0, 100, 500`). If the reference dataset has a `depth` dimension, then this keyword will automatically expand this `h2` into a list of `h2`s, one for each depth specified. The child nodes (the datasets under the `h2` are also copied and assigned a 'depth' value to be used in picking a layer out of the reference dataset. 