### PR TITLE
Fix dead link to ILAMB results HTML site

### DIFF
--- a/doc/first_steps.rst
+++ b/doc/first_steps.rst
@@ -202,7 +202,7 @@ data really is in the paths you specified in the configure file.
 
 Next we ran all model-confrontation pairs. In our parlance, a
 *confrontation* is a benchmark observational dataset and its
-accompanying analsys. We have two confrontations specified in our
+accompanying analysis. We have two confrontations specified in our
 configure file and one model, so we have two entries here. If the
 analysis completed without error, you will see a green ``Completed``
 text appear along with the runtime. Here we see that ``albedo`` took a
@@ -212,7 +212,7 @@ additional burden of reading in two datasets and combining them.
 The next stage is the post-processing. This is done as a separate loop
 to exploit some parallelism. All the work in a model-confrontation
 pair is purely local to the pair. Yet plotting results on the same
-scale implies that we know the maxmimum and minimum values from all
+scale implies that we know the maximum and minimum values from all
 models and thus requires the communcation of this information. Here,
 as we are plotting only over the globe and not extra regions, the
 plotting occurs quickly.

--- a/doc/ilamb_fetch.rst
+++ b/doc/ilamb_fetch.rst
@@ -24,7 +24,7 @@ to the following::
   Download replacements? [y/n]
 
 This tool looks at a remote location (by default the location of the
-land datasets) and compares it to a local location (by defult
+land datasets) and compares it to a local location (by default
 ``ILAMB_ROOT`` or ``./``). It detects for the presence and version of
 the data on your local machine and populates a list for download. The
 tool will then prompt you to rerun to check for file validity.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,4 +36,4 @@ Documentation
    
 .. _ILAMB:     http://www.ilamb.org/
 .. _github:    https://github.com/rubisco-sfa/ILAMB.git
-.. _site:      https://www.ilamb.org/CMIP5/esmHistorical/
+.. _site:      https://www.ilamb.org/results.html


### PR DESCRIPTION
Just a small fix of a link in the documentation.