### PR TITLE
Suppress warning related to string comparison

### DIFF
--- a/src/ILAMB/ModelResult.py
+++ b/src/ILAMB/ModelResult.py
@@ -135,7 +135,7 @@ class ModelResult:
                         continue
                     if self.filter not in fileName:
                         continue
-                    if self.regex is not "":
+                    if self.regex != "":
                         m = re.search(self.regex, fileName)
                         if not m:
                             continue


### PR DESCRIPTION
Check for the empty string with != "" instead of `is not ""`. This is the correct syntax for python equality comparison.
Current `is not` is doing identity comparison and emits a warning.