### PR TITLE
FIX: Inconsistent relationship overall score computation, take 2

### DIFF
--- a/src/ILAMB/Scoreboard.py
+++ b/src/ILAMB/Scoreboard.py
@@ -358,7 +358,7 @@ def ConvertList(node):
     for key in s.keys():
         if key == "children":
             continue
-        x = s[key]
+        x = np.ma.masked_invalid(s[key])
         with np.errstate(under="ignore"):
             x = (x - x.mean()) / (x.std().clip(0.02) if x.std() > 1e-12 else 1)
         x.data[x.mask] = -999


### PR DESCRIPTION
@mcguirepatr I created a small example here which I think exhibits the problem you are seeing. This fixes at least that problem but not necessarily yours. Keep me posted and I will keep squashing these little bugs. 