### PR TITLE
Allow for flexible NetCDF dimension names

### DIFF
--- a/src/ILAMB/ilamblib.py
+++ b/src/ILAMB/ilamblib.py
@@ -751,9 +751,24 @@ def FromNetCDF4(
     attr = {attr: var.getncattr(attr) for attr in var.ncattrs()}
 
     # Check on dimensions
-    time_name = [name for name in var.dimensions if "time" in name.lower()]
-    lat_name = [name for name in var.dimensions if "lat" in name.lower()]
-    lon_name = [name for name in var.dimensions if "lon" in name.lower()]
+    time_name = [
+        name
+        for name in var.dimensions
+        for pattern in [".*time.*", "t$"]
+        if re.fullmatch(pattern, name.lower())
+    ]
+    lat_name = [
+        name
+        for name in var.dimensions
+        for pattern in [".*lat.*", "y$"]
+        if re.fullmatch(pattern, name.lower())
+    ]
+    lon_name = [
+        name
+        for name in var.dimensions
+        for pattern in [".*lon.*", "x$"]
+        if re.fullmatch(pattern, name.lower())
+    ]
     data_name = [
         name
         for name in var.dimensions


### PR DESCRIPTION
Currently ILAMB can only read NetCDF datasets which define the following spatiotemporal dimension names: `*time*`, `*lat*` and `*lon*` where `*` is a wildcard. This change allows ILAMB to recognise a broader set of spatiotemporal dimension names when reading NetCDF datasets such as `t`, `x` and `y` as well as those recognised in the current behaviour.