### PR TITLE
Use cf-conventions to infer dimension names

### DIFF
--- a/src/ILAMB/constants.py
+++ b/src/ILAMB/constants.py
@@ -320,3 +320,36 @@ time_opts["dtcycle"] = {
     "ticklabels": lbl_months,
     "ylabel": "unit",
 }
+
+# CF constants
+
+cf_coordinate_type_standard_names = {
+    "time": "time",
+    "lat": "latitude",
+    "lon": "longitude",
+}
+
+cf_coordinate_type_units = {
+    "lat": [
+        "degrees_north",
+        "degree_north",
+        "degree_N",
+        "degrees_N",
+        "degreeN",
+        "degreesN",
+    ],
+    "lon": [
+        "degrees_east",
+        "degree_east",
+        "degree_E",
+        "degrees_E",
+        "degreeE",
+        "degreesE",
+    ],
+}
+
+cf_coordinate_type_axis = {
+    "time": "T",
+    "lat": "Y",
+    "lon": "X",
+}


### PR DESCRIPTION
Currently ILAMB requires dimensions for time, latitude and longitude in NetCDF files to be called `time`, `lat` and `lon` respectively which is not CF-compliant. This change allows ILAMB to be more flexible in inferring the spatiotemporal dimension names by examining standard CF attributes on [coordinate types][cf_coordinate_types].

[cf_coordinate_types]: https://cfconventions.org/cf-conventions/cf-conventions.html#coordinate-types