### PR TITLE
fix unit error on ELM output and CLASS data std uncertainty

### DIFF
--- a/src/ILAMB/Variable.py
+++ b/src/ILAMB/Variable.py
@@ -1540,9 +1540,20 @@ class Variable:
                 data = data.data[ind]
                 data = np.ma.masked_array(data, mask=mask)
                 if self.data_bnds is not None:
-                    args.append([0, 1])
-                    ind = np.ix_(*args)
-                    data_bnds = self.data_bnds[ind]
+
+                    if self.data_bnds.shape == self.data.shape:
+                        ind = np.ix_(*args)
+                        # one std?
+                        data_bnds = np.ma.stack(
+                                            [self.data[ind]-self.data_bnds[ind],
+                                             self.data[ind]+self.data_bnds[ind]], axis=len(args))
+
+                        self.data_bnds = data_bnds
+                    else:
+                        args.append([0, 1])
+                        ind = np.ix_(*args)
+                        data_bnds = self.data_bnds[ind]
+
                 np.seterr(under="ignore", over="ignore")
                 frac = self.area / il.CellAreas(
                     self.lat, self.lon, self.lat_bnds, self.lon_bnds

--- a/src/ILAMB/Variable.py
+++ b/src/ILAMB/Variable.py
@@ -167,6 +167,7 @@ class Variable:
 
         # Add handling for some units which cf_units does not support
         unit = unit.replace("psu", "1e-3")
+        unit = unit.replace("proportion", "1")
 
         if not np.ma.isMaskedArray(data):
             data = np.ma.masked_array(data)


### PR DESCRIPTION

- Replaced the unit of "proportion" from ELM output to CF units compatible unit "1"
- Added a piece of code to test if the uncertainty provided by benchmark data is the upper and lower bounds of the data as assumed by ILAMB. If not, the uncertainty is assumed to be the std of the data, and the lower and upper bounds are set by its one std. 