### PR TITLE
add the 'site' in the dimension names for new fluxnet datasets

### DIFF
--- a/src/ILAMB/ilamblib.py
+++ b/src/ILAMB/ilamblib.py
@@ -840,7 +840,7 @@ def FromNetCDF4(
     data_name = [
         name
         for name in var.dimensions
-        if name.lower() in ["data", "lndgrid", "gridcell"]
+        if name.lower() in ["data", "lndgrid", "gridcell", "site"]
     ]
     missed = [
         name


### PR DESCRIPTION
fixes to rubisco-sfa/ILAMB-data#81