### PR TITLE
Update CLM configuration files for modified obs datasets

### DIFF
--- a/src/ILAMB/data/ilamb_nohoff_final_CLM.cfg
+++ b/src/ILAMB/data/ilamb_nohoff_final_CLM.cfg
@@ -20,19 +20,21 @@ weight         = 5
 skip_rmse      = True
 mass_weighting = True
 
-[Tropical]
-source     = "DATA/biomass/Tropical/biomass_0.5x0.5.nc"
+[ESACCI]
+source = "DATA/biomass/ESACCI/biomass.nc"
+scale_factor = 0.714 # x 0.5 (total mass to carbon) / 0.7 (above only to total)
 weight     = 20
 table_unit = "Pg"
 plot_unit  = "kg m-2"
 space_mean = False
 
-[GlobalCarbon]
-source     = "DATA/biomass/GLOBAL.CARBON/biomass_0.5x0.5.nc"
-weight     = 16
-table_unit = "Pg"
-plot_unit  = "kg m-2"
-space_mean = False
+[GEOCARBON]
+source       = "DATA/biomass/GEOCARBON/biomass.nc"
+scale_factor = 0.714 # x 0.5 (total mass to carbon) / 0.7 (above only to total)
+weight       = 16
+table_unit   = "Pg"
+plot_unit    = "kg m-2"
+space_mean   = False
 
 [NBCD2000]
 source     = "DATA/biomass/NBCD2000/biomass_0.5x0.5.nc"
@@ -41,22 +43,30 @@ table_unit = "Pg"
 plot_unit  = "kg m-2"
 space_mean = False
 
-[USForest]
-source     = "DATA/biomass/USForest/biomass_0.5x0.5.nc"
-weight     = 8
+[Saatchi2011]
+source     = "DATA/biomass/Saatchi2011/biomass_0.5x0.5.nc"
+weight     = 16
 table_unit = "Pg"
 plot_unit  = "kg m-2"
 space_mean = False
 
 [Thurner]
 source = "DATA/biomass/Thurner/biomass_0.5x0.5.nc"
-weight     = 20
+weight     = 16
 table_unit = "Pg"
 plot_unit  = "kg m-2"
 space_mean = False
 
-[ESACCI]
-source = "DATA/biomass/ESACCI/biomass.nc"
+[USForest]
+source     = "DATA/biomass/USForest/biomass_0.5x0.5.nc"
+scale_factor = 0.714 # x 0.5 (total mass to carbon) / 0.7 (above only to total)
+weight     = 8
+table_unit = "Pg"
+plot_unit  = "kg m-2"
+space_mean = False
+
+[XuSaatchi2021]
+source     = "DATA/biomass/XuSaatchi2021/XuSaatchi.nc"
 weight     = 20
 table_unit = "Pg"
 plot_unit  = "kg m-2"
@@ -72,7 +82,7 @@ weight         = 4
 cmap           = "OrRd"
 mass_weighting = True
 
-[GFED4.1S]          
+[GFED4.1S]
 source        = "DATA/burntArea/GFED4.1S/burntArea.nc"
 weight        = 20
 relationships = "Precipitation/GPCPv2.3","SurfaceAirTemperature/CRU4.02"
@@ -81,10 +91,10 @@ relationships = "Precipitation/GPCPv2.3","SurfaceAirTemperature/CRU4.02"
 
 [h2: Carbon Dioxide]
 variable      = "co2"
-ctype         = "ConfCO2"
 weight        = 5
 
 [NOAA.emulated]
+ctype         = "ConfCO2"
 source        = "DATA/co2/NOAA.GMD/co2.nc"
 emulated_flux = "NBP"
 sites         = "alt,asc,azr,bhd,bmw,brw,cba,cgo,chr,crz,gmi,hba,ice,key,kum,mhd,mid,pocs35,pocs30,pocs25,pocs20,pocs15,pocs10,pocs05,poc000,pocn05,pocn10,pocn15,pocn20,pocn25,psa,rpb,sey,shm,smo,spo,syo,zep"
@@ -119,7 +129,7 @@ table_unit    = "Pg yr-1"
 plot_unit     = "g m-2 d-1"
 space_mean    = False
 skip_iav      = True
-relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.1","SurfaceNetSWRadiation/CERESed4.1","SurfaceAirTemperature/CRU4.02"
+relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.2","SurfaceNetSWRadiation/CERESed4.2","SurfaceAirTemperature/CRU4.02"
 
 [WECANN]
 source        = "DATA/gpp/WECANN/gpp.nc"
@@ -135,7 +145,7 @@ table_unit    = "Pg yr-1"
 plot_unit     = "g m-2 d-1"
 space_mean    = False
 skip_iav      = True
-relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.1","SurfaceNetSWRadiation/CERESed4.1","SurfaceAirTemperature/CRU4.02"
+relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.2","SurfaceNetSWRadiation/CERESed4.2","SurfaceAirTemperature/CRU4.02"
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -173,6 +183,11 @@ ctype    = "ConfNBP"
 [GCP]      
 source   = "DATA/nbp/GCP/nbp_1959-2016.nc"
 weight   = 20
+
+[Hoffman]
+source      = "DATA/nbp/HOFFMAN/nbp_1850-2010.nc"
+weight      = 20
+skip_taylor = True
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -265,8 +280,8 @@ fracpeat_source = "DATA/cSoil/Koven/fracpeat_0.5x0.5.nc"
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [h2: Nitrogen Fixation]
-variable = "FFIX_TO_SMINN"
-alternate_vars = "fBNF"
+variable = "fBNF"
+derived  = "FFIX_TO_SMINN+NFIX"
 cmap = "Greens"
 weight = 3
 
@@ -276,6 +291,19 @@ table_unit = "Tg yr-1"
 plot_unit  = "kg ha-1 yr-1"
 space_mean = False
 weight     = 16
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Methane]
+variable       = "FCH4"
+alternate_vars = "ch4"
+cmap           = "Greens"
+mass_weighting = True
+
+[FluxnetANN]
+source     = "DATA/ch4/FluxnetANN/FCH4_F_ANN_monthly_wetland_tier1.nc"
+table_unit = "g m-2 d-1"
+plot_unit  = "g m-2 d-1"
 
 ###########################################################################
 
@@ -327,7 +355,6 @@ weight      = 9
 skip_rmse   = True
 
 [CLASS]
-variable    = "evapfrac"
 hfss_source = "DATA/hfss/CLASS/hfss.nc"
 hfls_source = "DATA/hfls/CLASS/hfls.nc"
 skip_rmse   = True
@@ -525,8 +552,8 @@ variable = "albedo"
 weight   = 1
 ctype    = "ConfAlbedo"
 
-[CERESed4.1]
-source   = "DATA/albedo/CERESed4.1/albedo.nc"
+[CERESed4.2]
+source   = "DATA/albedo/CERESed4.2/albedo.nc"
 weight   = 20
 
 [GEWEX.SRB]
@@ -544,8 +571,8 @@ variable = "rsus"
 alternate_vars = "FSR"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rsus/CERESed4.1/rsus.nc"
+[CERESed4.2]
+source   = "DATA/rsus/CERESed4.2/rsus.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -568,8 +595,8 @@ alternate_vars = "FSA"
 derived  = "rsds-rsus"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rsns/CERESed4.1/rsns.nc"
+[CERESed4.2]
+source   = "DATA/rsns/CERESed4.2/rsns.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -591,8 +618,8 @@ variable = "rlus"
 alternate_vars = "FIRE"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rlus/CERESed4.1/rlus.nc"
+[CERESed4.2]
+source   = "DATA/rlus/CERESed4.2/rlus.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -614,8 +641,8 @@ variable = "rlns"
 derived  = "FLDS-FIRE"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rlns/CERESed4.1/rlns.nc"
+[CERESed4.2]
+source   = "DATA/rlns/CERESed4.2/rlns.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -638,8 +665,8 @@ derived  = "FLDS-FIRE+FSDS-FSR"
 weight = 2
 cmap     = "RdPu"
 
-[CERESed4.1]
-source   = "DATA/rns/CERESed4.1/rns.nc"
+[CERESed4.2]
+source   = "DATA/rns/CERESed4.2/rns.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -767,9 +794,11 @@ space_mean = True
 
 [CLASS]
 source     = "DATA/pr/CLASS/pr.nc"
-plot_unit  = "mm d-1"
+land       = True
+weight     = 15
 table_unit = "mm d-1"
-weight     = 25
+plot_unit  = "mm d-1"
+space_mean = True
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -795,8 +824,8 @@ variable = "FSDS"
 alternate_vars = "rsds"
 weight   = 2
 
-[CERESed4.1]
-source   = "DATA/rsds/CERESed4.1/rsds.nc"
+[CERESed4.2]
+source   = "DATA/rsds/CERESed4.2/rsds.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -818,8 +847,8 @@ variable = "FLDS"
 alternate_vars = "rlds"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rlds/CERESed4.1/rlds.nc"
+[CERESed4.2]
+source   = "DATA/rlds/CERESed4.2/rlds.nc"
 weight   = 15
 
 [FLUXNET2015]

--- a/src/ILAMB/data/ilamb_nohoff_final_CLM_SP.cfg
+++ b/src/ILAMB/data/ilamb_nohoff_final_CLM_SP.cfg
@@ -33,7 +33,7 @@ table_unit    = "Pg yr-1"
 plot_unit     = "g m-2 d-1"
 space_mean    = False
 skip_iav      = True
-relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.1","SurfaceNetSWRadiation/CERESed4.1","SurfaceAirTemperature/CRU4.02"
+relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.2","SurfaceNetSWRadiation/CERESed4.2","SurfaceAirTemperature/CRU4.02"
 
 [WECANN]
 source        = "DATA/gpp/WECANN/gpp.nc"
@@ -49,7 +49,7 @@ table_unit    = "Pg yr-1"
 plot_unit     = "g m-2 d-1"
 space_mean    = False
 skip_iav      = True
-relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.1","SurfaceNetSWRadiation/CERESed4.1","SurfaceAirTemperature/CRU4.02"
+relationships = "Evapotranspiration/GLEAMv3.3a","Precipitation/GPCPv2.3","SurfaceDownwardSWRadiation/CERESed4.2","SurfaceNetSWRadiation/CERESed4.2","SurfaceAirTemperature/CRU4.02"
 
 ###########################################################################
 
@@ -299,8 +299,8 @@ variable = "albedo"
 weight   = 1
 ctype    = "ConfAlbedo"
 
-[CERESed4.1]
-source   = "DATA/albedo/CERESed4.1/albedo.nc"
+[CERESed4.2]
+source   = "DATA/albedo/CERESed4.2/albedo.nc"
 weight   = 20
 
 [GEWEX.SRB]
@@ -318,8 +318,8 @@ variable = "rsus"
 alternate_vars = "FSR"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rsus/CERESed4.1/rsus.nc"
+[CERESed4.2]
+source   = "DATA/rsus/CERESed4.2/rsus.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -342,8 +342,8 @@ alternate_vars = "FSA"
 derived  = "rsds-rsus"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rsns/CERESed4.1/rsns.nc"
+[CERESed4.2]
+source   = "DATA/rsns/CERESed4.2/rsns.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -365,8 +365,8 @@ variable = "rlus"
 alternate_vars = "FIRE"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rlus/CERESed4.1/rlus.nc"
+[CERESed4.2]
+source   = "DATA/rlus/CERESed4.2/rlus.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -388,8 +388,8 @@ variable = "rlns"
 derived  = "FLDS-FIRE"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rlns/CERESed4.1/rlns.nc"
+[CERESed4.2]
+source   = "DATA/rlns/CERESed4.2/rlns.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -412,8 +412,8 @@ derived  = "FLDS-FIRE+FSDS-FSR"
 weight = 2
 cmap     = "RdPu"
 
-[CERESed4.1]
-source   = "DATA/rns/CERESed4.1/rns.nc"
+[CERESed4.2]
+source   = "DATA/rns/CERESed4.2/rns.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -540,10 +540,12 @@ plot_unit  = "mm d-1"
 space_mean = True
 
 [CLASS]
-source     = "DATA/pr/CLASS/pr.nc"
-plot_unit  = "mm d-1"
-table_unit = "mm d-1"
-weight     = 25
+source         = "DATA/pr/CLASS/pr.nc"
+land           = True
+weight         = 15
+table_unit     = "mm d-1"
+plot_unit      = "mm d-1"
+space_mean     = True
 
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -569,8 +571,8 @@ variable = "FSDS"
 alternate_vars = "rsds"
 weight   = 2
 
-[CERESed4.1]
-source   = "DATA/rsds/CERESed4.1/rsds.nc"
+[CERESed4.2]
+source   = "DATA/rsds/CERESed4.2/rsds.nc"
 weight   = 15
 
 [FLUXNET2015]
@@ -592,8 +594,8 @@ variable = "FLDS"
 alternate_vars = "rlds"
 weight   = 1
 
-[CERESed4.1]
-source   = "DATA/rlds/CERESed4.1/rlds.nc"
+[CERESed4.2]
+source   = "DATA/rlds/CERESed4.2/rlds.nc"
 weight   = 15
 
 [FLUXNET2015]


### PR DESCRIPTION
Update ilamb_nohoff_final_CLM_SP.cfg and ilamb_nohoff_final_CLM.cfg (the CLM SP and BGC configuration files) to account for new and modifed obs datasets.
I followed the latest ilamb.cfg to do this.
Hopefully, this would address #113 .
Tested these configuration files using our installation of ILAMB master.  Sample output here:

https://webext.cgd.ucar.edu/I20TR/ctsm53041_54surfdata_snowTherm_100_HIST/lnd/_build_snowThermI100_ILAMBv2.7.2_FLUXNETFix/